### PR TITLE
April 11 changes

### DIFF
--- a/Assets/Camera/CameraController.prefab
+++ b/Assets/Camera/CameraController.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2670423057232084553}
   - component: {fileID: 1560601628073206214}
+  - component: {fileID: 1932844163157906119}
   m_Layer: 0
   m_Name: PlayerFollowCamera
   m_TagString: Untagged
@@ -72,6 +73,36 @@ MonoBehaviour:
         m_Calls: []
   m_LegacyBlendHint: 0
   m_ComponentOwner: {fileID: 2137255024630178173}
+--- !u!114 &1932844163157906119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 348431224331853540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e501d18bb52cf8c40b1853ca4904654f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_CollideAgainst:
+    serializedVersion: 2
+    m_Bits: 257
+  m_IgnoreTag: 
+  m_TransparentLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_MinimumDistanceFromTarget: 0.1
+  m_AvoidObstacles: 1
+  m_DistanceLimit: 0
+  m_MinimumOcclusionTime: 0
+  m_CameraRadius: 0.1
+  m_Strategy: 1
+  m_MaximumEffort: 4
+  m_SmoothingTime: 0
+  m_Damping: 0
+  m_DampingWhenOccluded: 0
+  m_OptimalTargetDistance: 0
 --- !u!1 &963585208302535189
 GameObject:
   m_ObjectHideFlags: 0
@@ -263,7 +294,7 @@ MonoBehaviour:
   lookThreshold: 0.01
   cinemachineCameraTarget: {fileID: 0}
   topClamp: 70
-  bottomClamp: -30
+  bottomClamp: -15
   cameraAngleOverride: 0
 --- !u!1 &5880579853255790260
 GameObject:

--- a/Assets/Characters/Main/MC_Animation_Controller.controller
+++ b/Assets/Characters/Main/MC_Animation_Controller.controller
@@ -109,7 +109,7 @@ AnimatorStateMachine:
     m_Position: {x: 260, y: -310, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1202108968121863510}
-    m_Position: {x: 650, y: -90, z: 0}
+    m_Position: {x: 830, y: -100, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5407572280580649611}
     m_Position: {x: 630, y: -340, z: 0}
@@ -738,6 +738,7 @@ AnimatorState:
   - {fileID: -522706627894055247}
   - {fileID: 1268921615294032208}
   - {fileID: 4115462887512316527}
+  - {fileID: 5154107227927936328}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -991,6 +992,31 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0.75
   m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5154107227927936328
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isAttacking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6471671769950555016}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.60526323
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Assets/Characters/Prefabs/MainCharacter.prefab
+++ b/Assets/Characters/Prefabs/MainCharacter.prefab
@@ -129,7 +129,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moveSpeed: 2
   sprintSpeed: 5.335
-  attackSpeed: 0.4
+  attackSpeed: 1
   rotationSmoothTime: 0.12
   speedChangeRate: 10
   jumpHeight: 1.2
@@ -170,6 +170,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   drawnDaggerRotation: {x: 0.6427876, y: 0, z: 0, w: 0.76604444}
   sheathedDaggerRotation: {x: 0.4545196, y: -0.5416751, z: -0.4545196, w: -0.5416751}
+  amalgamSwordRotation: {x: 0, y: 0, z: 0, w: 1}
   axeRotation: {x: 0, y: 0, z: 0, w: 1}
   bowRotation: {x: 0, y: 0, z: 0, w: 1}
 --- !u!114 &4792826243224289047

--- a/Assets/Characters/Prefabs/MainCharacter.prefab
+++ b/Assets/Characters/Prefabs/MainCharacter.prefab
@@ -130,6 +130,8 @@ MonoBehaviour:
   moveSpeed: 2
   sprintSpeed: 5.335
   attackSpeed: 1
+  backwardSpeed: 1.5
+  sidewaySpeed: 2
   rotationSmoothTime: 0.12
   speedChangeRate: 10
   jumpHeight: 1.2

--- a/Assets/Enemies/Prefabs/Amalgam.prefab
+++ b/Assets/Enemies/Prefabs/Amalgam.prefab
@@ -821,7 +821,7 @@ MonoBehaviour:
   _chaseSpeed: 2.5
   _attackRadius: 1.75
   _attackDuration: 1
-  _attackRotationSpeed: 2.5
+  _angularSpeed: 90
   _height: 2
   _baseHealth: 100
   _startingHealth: 0

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_apples.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_apples.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3315714296393109856}
   - component: {fileID: 7901795786038575910}
   - component: {fileID: 7525788340159858592}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_apples_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 163004174657376329}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6419187236850804161}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7901795786038575910
 MeshFilter:
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 2364243790871939078}
   - component: {fileID: 4604217538834115015}
   - component: {fileID: 6038074568851490021}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_apples_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -109,13 +109,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4396159832342145111}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6419187236850804161}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4604217538834115015
 MeshFilter:
@@ -178,7 +178,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6419187236850804161}
   - component: {fileID: 2256188382494855856}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_apples
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -192,6 +192,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5935278547815300987}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -201,7 +202,6 @@ Transform:
   - {fileID: 3315714296393109856}
   - {fileID: 2364243790871939078}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!205 &2256188382494855856
 LODGroup:
@@ -241,7 +241,7 @@ GameObject:
   - component: {fileID: 2123385224588831687}
   - component: {fileID: 4006941177706727810}
   - component: {fileID: 340751423047132367}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_apples_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -255,13 +255,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7513603357302551873}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6419187236850804161}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4006941177706727810
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_dead.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_dead.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1988025617893250342}
   - component: {fileID: 6759055787200995927}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_dead
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24,6 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1215182899609276316}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -33,7 +34,6 @@ Transform:
   - {fileID: 7117508975715571117}
   - {fileID: 1799755330681518831}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!205 &6759055787200995927
 LODGroup:
@@ -73,7 +73,7 @@ GameObject:
   - component: {fileID: 1799755330681518831}
   - component: {fileID: 3631142874527198405}
   - component: {fileID: 4772830539911952586}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_dead_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -87,13 +87,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2110101974054781677}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: -0.0016458168, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1988025617893250342}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3631142874527198405
 MeshFilter:
@@ -156,7 +156,7 @@ GameObject:
   - component: {fileID: 7117508975715571117}
   - component: {fileID: 4919535853178116811}
   - component: {fileID: 4520285889721809477}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_dead_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -170,13 +170,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7875350929978274829}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: -0.0016458168, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1988025617893250342}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4919535853178116811
 MeshFilter:
@@ -239,7 +239,7 @@ GameObject:
   - component: {fileID: 355686686542058714}
   - component: {fileID: 7275367467134081096}
   - component: {fileID: 1814185510865685987}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_dead_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -253,13 +253,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9055391635337348157}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: -0.0016458168, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1988025617893250342}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7275367467134081096
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_dead_cut.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_dead_cut.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1439603208813202615}
   - component: {fileID: 2618180078766244626}
   - component: {fileID: 266085804396066776}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_dead_cut
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1779396640715740685}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2618180078766244626
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_green.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_green.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1604534389263972203}
   - component: {fileID: 2450240378288737524}
   - component: {fileID: 1094804630965145243}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_green_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 570905906132603332}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4696216175943693753}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2450240378288737524
 MeshFilter:
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 8305029876632308500}
   - component: {fileID: 6974490863388874546}
   - component: {fileID: 2558605503083844748}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_green_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -109,13 +109,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2187513939821381110}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4696216175943693753}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6974490863388874546
 MeshFilter:
@@ -178,7 +178,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4696216175943693753}
   - component: {fileID: 537705250742567624}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_green
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -192,6 +192,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5361428799875542787}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -201,7 +202,6 @@ Transform:
   - {fileID: 2486815125958864585}
   - {fileID: 1604534389263972203}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!205 &537705250742567624
 LODGroup:
@@ -241,7 +241,7 @@ GameObject:
   - component: {fileID: 2486815125958864585}
   - component: {fileID: 6631951447468464209}
   - component: {fileID: 1613519660729417021}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_green_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -255,13 +255,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6567692543045439752}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4696216175943693753}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6631951447468464209
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_green_cut.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_green_cut.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 528506774677081659}
   - component: {fileID: 3529266890537746846}
   - component: {fileID: 1665925868165018964}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_green_cut
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 873261478477796481}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3529266890537746846
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_logs.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_logs.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4371144052285426531}
   - component: {fileID: 794524481623672006}
   - component: {fileID: 3234218433630908428}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_logs
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4026988788687868377}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &794524481623672006
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_pears.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_pears.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2966750739439028892}
   - component: {fileID: 8031637485679984109}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_pears
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24,6 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2479184009378418726}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -33,7 +34,6 @@ Transform:
   - {fileID: 9181186186337446699}
   - {fileID: 6095404779158058549}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!205 &8031637485679984109
 LODGroup:
@@ -73,7 +73,7 @@ GameObject:
   - component: {fileID: 6095404779158058549}
   - component: {fileID: 1584039189104781334}
   - component: {fileID: 8580298009914301585}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_pears_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -87,13 +87,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2613454675235345673}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2966750739439028892}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1584039189104781334
 MeshFilter:
@@ -157,7 +157,7 @@ GameObject:
   - component: {fileID: 3396174388722069082}
   - component: {fileID: 3651040237905038081}
   - component: {fileID: 7532243803686030394}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_pears_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -171,13 +171,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3491555602639996928}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2966750739439028892}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &3651040237905038081
 MeshFilter:
@@ -241,7 +241,7 @@ GameObject:
   - component: {fileID: 9181186186337446699}
   - component: {fileID: 31858204375945324}
   - component: {fileID: 2352935628247011077}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_pears_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -255,13 +255,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7765329102591482917}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2966750739439028892}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &31858204375945324
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_plums.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_plums.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 8254891333303301210}
   - component: {fileID: 8222655170643054932}
   - component: {fileID: 1414196137617344592}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_plums_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3503747439877303717}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7929462325123785727}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &8222655170643054932
 MeshFilter:
@@ -94,7 +94,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7929462325123785727}
   - component: {fileID: 2905107983372784782}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_plums
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -108,6 +108,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7296054959696050501}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -117,7 +118,6 @@ Transform:
   - {fileID: 8254891333303301210}
   - {fileID: 6965208583826785942}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!205 &2905107983372784782
 LODGroup:
@@ -157,7 +157,7 @@ GameObject:
   - component: {fileID: 3661800321207667961}
   - component: {fileID: 9204582415525613151}
   - component: {fileID: 1987643193280244065}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_plums_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -171,13 +171,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7389196695646074697}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7929462325123785727}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &9204582415525613151
 MeshFilter:
@@ -241,7 +241,7 @@ GameObject:
   - component: {fileID: 6965208583826785942}
   - component: {fileID: 4352938707021388631}
   - component: {fileID: 6140726643089354878}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_plums_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -255,13 +255,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7626970178412452963}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7929462325123785727}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4352938707021388631
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_stump.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Fruit_Tree_01_stump.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 7622724856221292152}
   - component: {fileID: 6802265350786472413}
   - component: {fileID: 8755691476161375511}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Fruit_Tree_01_stump
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7098389285256826050}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6802265350786472413
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_dead.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_dead.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1268050992877243359}
   - component: {fileID: 6323926895507881134}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_dead
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24,6 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1932841404346126693}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -33,7 +34,6 @@ Transform:
   - {fileID: 2534358327882011202}
   - {fileID: 5340731949621571375}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!205 &6323926895507881134
 LODGroup:
@@ -73,7 +73,7 @@ GameObject:
   - component: {fileID: 2809133384829089810}
   - component: {fileID: 2927318667073144412}
   - component: {fileID: 728806381982184805}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_dead_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -87,13 +87,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3362487869812425040}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1268050992877243359}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2927318667073144412
 MeshFilter:
@@ -156,7 +156,7 @@ GameObject:
   - component: {fileID: 5340731949621571375}
   - component: {fileID: 2617870471872453413}
   - component: {fileID: 4328895901199877293}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_dead_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -170,13 +170,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4723611995488449968}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1268050992877243359}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2617870471872453413
 MeshFilter:
@@ -239,7 +239,7 @@ GameObject:
   - component: {fileID: 2534358327882011202}
   - component: {fileID: 6272690288195183828}
   - component: {fileID: 7058119992877278399}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_dead_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -253,13 +253,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6476640290302085614}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1268050992877243359}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6272690288195183828
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_dead_cut.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_dead_cut.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4131062105692079671}
   - component: {fileID: 1079633060130294162}
   - component: {fileID: 2963183586251210072}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_dead_cut
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3611794222474779789}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1079633060130294162
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_green.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_green.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2812287724108380338}
   - component: {fileID: 1394057832663195253}
   - component: {fileID: 1272740766238620194}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_green_LOD0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -119,7 +119,7 @@ GameObject:
   - component: {fileID: 6236222268586821143}
   - component: {fileID: 8379061657498843178}
   - component: {fileID: 7013654394060798706}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_green_LOD2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -202,7 +202,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6894979521318456901}
   - component: {fileID: 1870679391148259636}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_green
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -265,7 +265,7 @@ GameObject:
   - component: {fileID: 8538897729451581637}
   - component: {fileID: 6203392517139920881}
   - component: {fileID: 8000319770140492376}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_green_LOD1
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_green_cut.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_green_cut.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5705539758440290059}
   - component: {fileID: 8683500536680192174}
   - component: {fileID: 6873912444871011428}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_green_cut
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4928616408704863665}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &8683500536680192174
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_logs.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_logs.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2489856308131526256}
   - component: {fileID: 1522890174684395989}
   - component: {fileID: 3658774210864352543}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_logs
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3010216212467657930}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1522890174684395989
 MeshFilter:

--- a/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_stump.prefab
+++ b/Assets/Polytope Studio/Lowpoly_Environments/Prefabs/Trees/PT_Pine_Tree_03_stump.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2311925644611836766}
   - component: {fileID: 1709757669461153019}
   - component: {fileID: 3485417514373718065}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: PT_Pine_Tree_03_stump
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3125019525012259300}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1709757669461153019
 MeshFilter:

--- a/Assets/Scenes/Playground.unity
+++ b/Assets/Scenes/Playground.unity
@@ -836,6 +836,11 @@ PrefabInstance:
       propertyPath: m_Follow
       value: 
       objectReference: {fileID: 1781960699}
+    - target: {fileID: 1560601628073206214, guid: 3494377b2b17f024394cac317ad3811f,
+        type: 3}
+      propertyPath: m_LookAt
+      value: 
+      objectReference: {fileID: 1781960699}
     - target: {fileID: 3369365311719673110, guid: 3494377b2b17f024394cac317ad3811f,
         type: 3}
       propertyPath: cinemachineCameraTarget

--- a/Assets/Scenes/VillageTest.unity
+++ b/Assets/Scenes/VillageTest.unity
@@ -381,7 +381,7 @@ Terrain:
   m_ReflectionProbeUsage: 1
   m_MaterialTemplate: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
   m_BakeLightProbesForTrees: 1
-  m_PreserveTreePrototypeLayers: 0
+  m_PreserveTreePrototypeLayers: 1
   m_DeringLightProbesForTrees: 1
   m_ReceiveGI: 1
   m_ScaleInLightmap: 0.0256
@@ -1176,6 +1176,11 @@ PrefabInstance:
     - target: {fileID: 1560601628073206214, guid: 3494377b2b17f024394cac317ad3811f,
         type: 3}
       propertyPath: m_Follow
+      value: 
+      objectReference: {fileID: 624219978}
+    - target: {fileID: 1560601628073206214, guid: 3494377b2b17f024394cac317ad3811f,
+        type: 3}
+      propertyPath: m_LookAt
       value: 
       objectReference: {fileID: 624219978}
     - target: {fileID: 2670423057232084553, guid: 3494377b2b17f024394cac317ad3811f,

--- a/Assets/UI/GameOverController.prefab
+++ b/Assets/UI/GameOverController.prefab
@@ -137,7 +137,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 160, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6680886478694132409
 CanvasRenderer:
@@ -216,7 +216,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 160, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3958470134793003438
 CanvasRenderer:
@@ -298,8 +298,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -17.4}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0, y: -27.4}
+  m_SizeDelta: {x: 160, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4460015324700254110
 CanvasRenderer:
@@ -511,7 +511,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -8.6}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 160, y: 15}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2489960966177397654
 CanvasRenderer:
@@ -660,6 +660,7 @@ MonoBehaviour:
   GameOverText: {fileID: 2439419659988041086}
   RestartButton: {fileID: 5868262626695981911}
   MainMenuButton: {fileID: 6075896493608725712}
+  gameOverTextStartPosition: {x: 0, y: 0, z: 0}
 --- !u!1 &8721448068371015419
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/scripts/Enemies/EnemyData.cs
+++ b/Assets/scripts/Enemies/EnemyData.cs
@@ -141,7 +141,7 @@ public class EnemyData : MonoBehaviour, IAttackData
         healthBarSliderGameObject.transform.rotation = Quaternion.LookRotation(sliderDirection);
         if (Mathf.Approximately(healthBarSlider.value, 1f))
         {
-            //healthBarSliderGameObject.SetActive(false);
+            healthBarSliderGameObject.SetActive(false);
         } 
         else
         {

--- a/Assets/scripts/Enemies/EnemyData.cs
+++ b/Assets/scripts/Enemies/EnemyData.cs
@@ -14,10 +14,11 @@ public class EnemyData : MonoBehaviour, IAttackData
     public float chaseSpeed { get { return _chaseSpeed; } private set { _chaseSpeed = value; } }
     public float attackRadius { get { return _attackRadius; } private set { _attackRadius = value; } }
     public float attackDuration { get { return _attackDuration; } private set { _attackDuration = value; } }
-    public float attackRotationSpeed { get { return _attackRotationSpeed; } private set { _attackRotationSpeed = value; } }
+    public float angularSpeed { get { return _angularSpeed; } private set { _angularSpeed = value; } }
     public float height { get { return _height; } private set { _height = value; } }
     public float GetAttackPower () => _baseAttackPower;
     public GameObject mainCharacter { get { return _mainCharacter; } private set { _mainCharacter = value; } }
+    public Rigidbody rb { get { return _rb; } private set { _rb = value; } }
 
     public Vector3 spawnPosition { get { return _spawnPosition; } private set { _spawnPosition = value; } }
 
@@ -55,8 +56,10 @@ public class EnemyData : MonoBehaviour, IAttackData
     [SerializeField]
     [Tooltip("In seconds.")]
     private float _attackDuration = 1f;
+
     [SerializeField]
-    private float _attackRotationSpeed = 2.5f;
+    [Tooltip("In deg/s.")]
+    private float _angularSpeed = 90f;
 
 
     [Header("Enemy Character Information")]
@@ -81,6 +84,7 @@ public class EnemyData : MonoBehaviour, IAttackData
     private GameObject mainCamera;
 
     private PlayerStats playerStats;
+    private Rigidbody _rb;
 
 
     [Header("Health Slider Fields")]
@@ -124,6 +128,9 @@ public class EnemyData : MonoBehaviour, IAttackData
         healthBarSliderGameObject.transform.localPosition = new Vector3(0, healthBarSliderY, healthBarSliderZ);
         healthBarSlider = healthBarSliderGameObject.GetComponent<Slider>();
         Debug.Assert(healthBarSlider != null);
+
+        _rb = GetComponent<Rigidbody>();
+        Debug.Assert(_rb != null);
 
         // Temp starting health.
         _startingHealth = _baseHealth;

--- a/Assets/scripts/Enemies/EnemyTakeDamage.cs
+++ b/Assets/scripts/Enemies/EnemyTakeDamage.cs
@@ -44,5 +44,6 @@ public class EnemyTakeDamage : TakeDamageBase
         }
 
         enemyData.TakeDamage(damage);
+        DamageIndicator.Instance.IndicateDamage(damage, attackingWeapon.transform.position);
     }
 }

--- a/Assets/scripts/Player/MC_TakeDamageController.cs
+++ b/Assets/scripts/Player/MC_TakeDamageController.cs
@@ -52,8 +52,6 @@ public class MC_TakeDamageController : TakeDamageBase
                 Debug.Log("DamageDealt: " + damageDealt);
                 PlayerStats.Instance.TakeDamage(damageDealt);
 
-                // TODO: For testing purposes. The plan is to use damage indicators only for player damaging enemy.
-                DamageIndicator.Instance.IndicateDamage(damageDealt * 100f, attackingWeapon.transform.position);
             }
         }
         else

--- a/Assets/scripts/Weapons/WeaponPickup.cs
+++ b/Assets/scripts/Weapons/WeaponPickup.cs
@@ -128,7 +128,14 @@ private void CreatePickupUI()
         userWeaponController.Add(userComponent);
 
         if (other.CompareTag("Player"))
-            pickupPromptUI.enabled = true;
+        {
+            MC_EquippedWeapon mcEquippedWeapon = (MC_EquippedWeapon)userComponent;
+            // TODO: Add better logic once inventory is implemented.
+            if (!mcEquippedWeapon.hasWeaponEquipped())
+            {
+                pickupPromptUI.enabled = true;
+            }
+        }
     }
 
     private void OnTriggerExit(Collider other)

--- a/Assets/scripts/baseCalsses/DamageIndicator.cs
+++ b/Assets/scripts/baseCalsses/DamageIndicator.cs
@@ -63,7 +63,7 @@ public class DamageIndicator : MonoBehaviour
         }
     }
 
-    public IEnumerator DamageTextSequence(GameObject textPrefabInstance, float damage, Vector3 hitPosition, Color color)
+    private IEnumerator DamageTextSequence(GameObject textPrefabInstance, float damage, Vector3 hitPosition, Color color)
     {
         GameObject damageText = textPrefabInstance.transform.Find("DamageText").gameObject;
         RectTransform rectTransform = damageText.GetComponent<RectTransform>();

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -18,7 +18,7 @@ TagManager:
   - Enemies
   - Terrain
   - NPCFighters
-  - 
+  - Tree
   - 
   - 
   - 


### PR DESCRIPTION
# Description

- Add functionality to lock player rotation to face away from camera if player has a weapon drawn
- Improve enemy AI by relying less on NavMesh agents
- Fix game over button hit boxes
- Improve responsiveness of jog to attack transition
- Add damage indicators when attacking enemy and remove the reverse
- Fix camera clipping through the terrain layer and add logic to clip through trees
- Add temp logic to not display weapon pickup if user already has an equipped weapon (to be refactored when inventory is implemented)


# Issue(s)

N/A